### PR TITLE
feat: add mcp() hook with @azure/mcp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request: {}
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Microsoft Azure: CLI tools (`azure-cli`), extensions, prompt
+integration, and MCP server (`@azure/mcp` via npm) for AI-driven Azure
+resource and subscription management.
 
 ## Contributing
 
@@ -37,12 +39,13 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::azure::completions::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module
+    - dir
 - `p6df::modules::azure::deps()`
 - `p6df::modules::azure::external::brew()`
 - `p6df::modules::azure::home::symlink()`
 - `p6df::modules::azure::langs()`
+- `p6df::modules::azure::mcp()`
 - `str str = p6df::modules::azure::prompt::mod()`
 
 ## Hierarchy

--- a/init.zsh
+++ b/init.zsh
@@ -129,3 +129,17 @@ p6df::modules::azure::prompt::mod() {
 
   p6_return_str "$str"
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::azure::mcp()
+#
+#>
+######################################################################
+p6df::modules::azure::mcp() {
+
+  p6_js_npm_global_install "@azure/mcp"
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary
- Adds `p6df::modules::azure::mcp()` installing `@azure/mcp` (official Microsoft package) via npm
- Regenerated README with updated function list
- Restored Summary section

## Test plan
- [ ] `p6df::modules::azure::mcp()` installs `@azure/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)