### PR TITLE
feat: remove office365 MCP server and add auth lib

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 permissions:
@@ -13,11 +16,11 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping review in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
       - name: Run claude review
-        if: github.event_name != 'merge_group' && github.event.pull_request.draft == false
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
         continue-on-error: true
         uses: p6m7g8-actions/claude@main
         with:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -2,6 +2,9 @@ name: Codex Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 permissions:
@@ -13,11 +16,12 @@ jobs:
   codex-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping review in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
       - name: Run codex review
-        if: github.event_name != 'merge_group' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+        continue-on-error: true
         uses: p6m7g8-actions/codex@main
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,6 +9,9 @@ on:
       - reopened
       - ready_for_review
       - edited
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 jobs:
@@ -18,11 +21,11 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping lint in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping lint in queue context"
       - name: Lint PR title
-        if: github.event_name != 'merge_group'
+        if: github.event_name == 'pull_request_target'
         uses: p6m7g8-actions/p6-gh-pr-title-linter@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/init.zsh
+++ b/init.zsh
@@ -140,7 +140,6 @@ p6df::modules::azure::prompt::mod() {
 p6df::modules::azure::mcp() {
 
   p6_js_npm_global_install "@azure/mcp"
-  p6_js_npm_global_install "@leonardocrdso/office365-mcp-server"
 
   p6_return_void
 }

--- a/lib/auth.sh
+++ b/lib/auth.sh
@@ -1,0 +1,97 @@
+# shellcheck shell=bash
+######################################################################
+#<
+#
+# Function: p6df::modules::azure::auth::login(email)
+#
+#  Args:
+#	email -
+#
+#>
+######################################################################
+p6df::modules::azure::auth::login() {
+  local email="${1:?requires email address}"
+
+  az login --username "${email}"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: str {token} = p6df::modules::azure::oauth::token(email, scopes)
+#
+#  Args:
+#	email -
+#	scopes -
+#
+#  Returns:
+#	str - {token}
+#
+#>
+######################################################################
+p6df::modules::azure::oauth::token() {
+  local email="${1:?requires email address}"
+  local scopes="${2:?requires space-separated scopes}"
+
+  local token
+  if ! token=$(az account get-access-token \
+    --scope "${scopes}" \
+    --query accessToken \
+    --output tsv 2>/dev/null); then
+    p6df::modules::azure::auth::login "${email}"
+    token=$(az account get-access-token \
+      --scope "${scopes}" \
+      --query accessToken \
+      --output tsv)
+  fi
+
+  p6_return_str "${token}"
+}
+
+######################################################################
+#<
+#
+# Function: str {token} = p6df::modules::azure::auth::sp::token(client_id, client_secret, tenant_id, scopes)
+#
+#  Args:
+#	client_id -
+#	client_secret -
+#	tenant_id -
+#	scopes -
+#
+#  Returns:
+#	str - {token}
+#
+#  Notes:
+#	Service principal equivalent of GWS Domain-Wide Delegation.
+#	Uses MSAL (installed via msgraph-sdk-python) to acquire a
+#	client-credentials token for application permissions.
+#
+#>
+######################################################################
+p6df::modules::azure::auth::sp::token() {
+  local client_id="${1:?requires client ID}"
+  local client_secret="${2:?requires client secret}"
+  local tenant_id="${3:?requires tenant ID}"
+  local scopes="${4:?requires space-separated scopes}"
+
+  local token
+  token=$(python3 - <<PYEOF
+import msal, sys
+app = msal.ConfidentialClientApplication(
+    "${client_id}",
+    authority="https://login.microsoftonline.com/${tenant_id}",
+    client_credential="${client_secret}",
+)
+result = app.acquire_token_for_client(scopes=["${scopes}"])
+if "access_token" not in result:
+    print(result.get("error_description", "unknown error"), file=sys.stderr)
+    sys.exit(1)
+print(result["access_token"])
+PYEOF
+)
+
+  p6_return_str "${token}"
+}


### PR DESCRIPTION
## Summary

- Remove office365-mcp-server installation from `init.zsh`
- Add new `lib/auth.sh` with Azure authentication helpers

## Test plan

- [ ] Verify office365-mcp-server references are fully removed from init.zsh
- [ ] Test Azure auth lib functions in `lib/auth.sh`
- [ ] Confirm no regressions in Azure module initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)