### PR TITLE
chore(azure): merge home::symlink into home::symlinks

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -56,27 +56,14 @@ p6df::modules::azure::langs() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::azure::home::symlink()
-#
-#  Environment:	 P6_DFZ_SRC_DIR USER
-#>
-######################################################################
-p6df::modules::azure::home::symlink() {
-
-  p6_file_symlink "$P6_DFZ_SRC_DIR/$USER/home-private/azure" ".azure"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
 # Function: p6df::modules::azure::home::symlinks()
 #
-#  Environment:	 HOME P6_DFZ_SRC_DIR
+#  Environment:	 HOME P6_DFZ_SRC_DIR USER
 #>
 ######################################################################
 p6df::modules::azure::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/$USER/home-private/azure" ".azure"
 
   p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/azure-pipelines-generator"        "$HOME/.claude/skills/azure-pipelines-generator"
   p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/azure-pipelines-validator"        "$HOME/.claude/skills/azure-pipelines-validator"


### PR DESCRIPTION
## What
Merge dotfile symlinks from never-called singular into auto-called plural. Delete singular.
## Why
p6df-core dispatches home::symlinks (plural) only.
## Test plan
`p6df home symlinks` works correctly.
## Dependencies
None