### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::azure::deps()
-#
-#>
-######################################################################
 p6df::modules::azure::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-zsh
@@ -13,11 +7,31 @@ p6df::modules::azure::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::azure::external::brews()
-#
-#>
+p6df::modules::azure::completions::init() {
+  local _module="$1"
+  local dir="$2"
+
+  autoload -U +X bashcompinit && bashcompinit
+  if p6_file_exists "$HOMEBREW_PREFIX/etc/bash_completion.d/az"; then
+    p6_file_load "$HOMEBREW_PREFIX/etc/bash_completion.d/az"
+  fi
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::azure::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/$USER/home-private/azure" ".azure"
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/azure-pipelines-generator"        "$HOME/.claude/skills/azure-pipelines-generator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/azure-pipelines-validator"        "$HOME/.claude/skills/azure-pipelines-validator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/hashicorp/agent-skills/packer/builders/skills/azure-image-builder"                       "$HOME/.claude/skills/azure-image-builder"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/hashicorp/agent-skills/packer/builders/skills/windows-builder"                           "$HOME/.claude/skills/windows-builder"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::azure::external::brews() {
 
@@ -29,12 +43,6 @@ p6df::modules::azure::external::brews() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::azure::langs()
-#
-#>
 ######################################################################
 p6df::modules::azure::langs() {
 
@@ -54,25 +62,40 @@ p6df::modules::azure::langs() {
 }
 
 ######################################################################
+p6df::modules::azure::mcp() {
+
+  p6_js_npm_global_install "@azure/mcp"
+
+  p6df::modules::anthropic::mcp::server::add "azure" "npx" "-y" "@azure/mcp"
+  p6df::modules::openai::mcp::server::add "azure" "npx" "-y" "@azure/mcp"
+
+  p6_return_void
+}
+######################################################################
+#<
+#
+# Function: p6df::modules::azure::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::azure::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::azure::langs()
+#
+#>
+######################################################################
 #<
 #
 # Function: p6df::modules::azure::home::symlinks()
 #
 #  Environment:	 HOME P6_DFZ_SRC_DIR USER
 #>
-######################################################################
-p6df::modules::azure::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_DIR/$USER/home-private/azure" ".azure"
-
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/azure-pipelines-generator"        "$HOME/.claude/skills/azure-pipelines-generator"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/azure-pipelines-validator"        "$HOME/.claude/skills/azure-pipelines-validator"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/hashicorp/agent-skills/packer/builders/skills/azure-image-builder"                       "$HOME/.claude/skills/azure-image-builder"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/hashicorp/agent-skills/packer/builders/skills/windows-builder"                           "$HOME/.claude/skills/windows-builder"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -84,17 +107,6 @@ p6df::modules::azure::home::symlinks() {
 #
 #  Environment:	 HOMEBREW_PREFIX
 #>
-######################################################################
-p6df::modules::azure::completions::init() {
-  local _module="$1"
-  local dir="$2"
-
-  autoload -U +X bashcompinit && bashcompinit
-  p6_file_load "$HOMEBREW_PREFIX/etc/bash_completion.d/az"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -141,13 +153,3 @@ p6df::modules::azure::prompt::context() {
 # Function: p6df::modules::azure::mcp()
 #
 #>
-######################################################################
-p6df::modules::azure::mcp() {
-
-  p6_js_npm_global_install "@azure/mcp"
-
-  p6df::modules::anthropic::mcp::server::add "azure" "npx" "-y" "@azure/mcp"
-  p6df::modules::openai::mcp::server::add "azure" "npx" "-y" "@azure/mcp"
-
-  p6_return_void
-}

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::azure::deps()
+#
+#>
+######################################################################
 p6df::modules::azure::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-zsh
@@ -7,18 +13,34 @@ p6df::modules::azure::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::azure::completions::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#  Environment:	 HOMEBREW_PREFIX
+#>
+######################################################################
 p6df::modules::azure::completions::init() {
   local _module="$1"
   local dir="$2"
 
   autoload -U +X bashcompinit && bashcompinit
-  if p6_file_exists "$HOMEBREW_PREFIX/etc/bash_completion.d/az"; then
-    p6_file_load "$HOMEBREW_PREFIX/etc/bash_completion.d/az"
-  fi
+  p6_file_load "$HOMEBREW_PREFIX/etc/bash_completion.d/az"
 
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::azure::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR USER
+#>
 ######################################################################
 p6df::modules::azure::home::symlinks() {
 
@@ -33,6 +55,12 @@ p6df::modules::azure::home::symlinks() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::azure::external::brews()
+#
+#>
+######################################################################
 p6df::modules::azure::external::brews() {
 
   p6df::core::homebrew::cli::brew::install azure-cli
@@ -43,6 +71,12 @@ p6df::modules::azure::external::brews() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::azure::langs()
+#
+#>
 ######################################################################
 p6df::modules::azure::langs() {
 
@@ -62,6 +96,12 @@ p6df::modules::azure::langs() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::azure::mcp()
+#
+#>
+######################################################################
 p6df::modules::azure::mcp() {
 
   p6_js_npm_global_install "@azure/mcp"
@@ -71,42 +111,6 @@ p6df::modules::azure::mcp() {
 
   p6_return_void
 }
-######################################################################
-#<
-#
-# Function: p6df::modules::azure::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::azure::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::azure::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::azure::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR USER
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::azure::completions::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#  Environment:	 HOMEBREW_PREFIX
-#>
 ######################################################################
 #<
 #
@@ -147,9 +151,3 @@ p6df::modules::azure::prompt::context() {
   p6_return_str "$str"
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::azure::mcp()
-#
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None